### PR TITLE
Remove duplicate edges from MoleculeGraph using local_env strategy

### DIFF
--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1174,7 +1174,8 @@ class MoleculeGraph(MSONable):
         if reorder:
             # Reverse order of nodes to match with molecule
             n = len(mg.molecule)
-            mapping = {i: (n-i) for i in range(n)}
+            mapping = {i: (n - i) for i in range(n)}
+            mapping = {i: (j - 1) for i, j in mapping.items()}
 
             mg.graph = nx.relabel_nodes(mg.graph, mapping)
 

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1178,6 +1178,14 @@ class MoleculeGraph(MSONable):
 
             mg.graph = nx.relabel_nodes(mg.graph, mapping)
 
+        duplicates = []
+        for edge in mg.graph.edges:
+            if edge[2] != 0:
+                duplicates.append(edge)
+
+        for duplicate in duplicates:
+            mg.graph.remove_edge(duplicate[0], duplicate[1], key=duplicate[2])
+
         return mg
 
     @property

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -7,7 +7,6 @@ from __future__ import division, unicode_literals
 import unittest
 import os
 import copy
-import matplotlib
 
 from monty.serialization import loadfn#, dumpfn
 
@@ -423,6 +422,10 @@ class MoleculeGraphTest(unittest.TestCase):
                 self.assertEqual(
                     mol_graph.graph.node[node]["coords"][ii],
                     ref_mol_graph.graph.node[node]["coords"]["data"][ii])
+
+        mol_graph_edges = build_MoleculeGraph(self.pc, edges=self.pc_edges)
+        mol_graph_strat = build_MoleculeGraph(self.pc, strategy=MinimumDistanceNN)
+        self.assertTrue(mol_graph_edges.isomorphic_to(mol_graph_strat))
 
     def test_properties(self):
         self.assertEqual(self.cyclohexene.name, "bonds")

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -13,7 +13,7 @@ from monty.serialization import loadfn#, dumpfn
 from pymatgen.command_line.critic2_caller import Critic2Output
 from pymatgen.core.structure import Molecule, Structure, FunctionalGroups, Site
 from pymatgen.analysis.graphs import *
-from pymatgen.analysis.local_env import MinimumDistanceNN, MinimumOKeeffeNN
+from pymatgen.analysis.local_env import MinimumDistanceNN, MinimumOKeeffeNN, OpenBabelNN
 
 try:
     import openbabel as ob
@@ -396,6 +396,7 @@ class MoleculeGraphTest(unittest.TestCase):
         del self.butadiene
         del self.cyclohexene
 
+    @unittest.skipIf(not ob, "OpenBabel not present. Skipping...")
     def test_build_MoleculeGraph(self):
         mol_graph = build_MoleculeGraph(self.pc_frag1, edges=self.pc_frag1_edges)
         # dumpfn(mol_graph.as_dict(), os.path.join(module_dir,"pc_frag1_mg.json"))
@@ -424,7 +425,7 @@ class MoleculeGraphTest(unittest.TestCase):
                     ref_mol_graph.graph.node[node]["coords"]["data"][ii])
 
         mol_graph_edges = build_MoleculeGraph(self.pc, edges=self.pc_edges)
-        mol_graph_strat = build_MoleculeGraph(self.pc, strategy=MinimumDistanceNN)
+        mol_graph_strat = build_MoleculeGraph(self.pc, strategy=OpenBabelNN, reorder=False, extend_structure=False)
         self.assertTrue(mol_graph_edges.isomorphic_to(mol_graph_strat))
 
     def test_properties(self):


### PR DESCRIPTION
Previously, MoleculeGraph.with_local_env_strategy would generate two edges for each perceived edge between nodes/atoms. This change removes that bug, which should improve functionality and make logical processing of MoleculeGraphs easier. In the future, the MultiDiGraph class used for MoleculeGraph (and StructureGraph) should probably be replaced with a Graph - this might, however, lead to complications for StructureGraph, which includes nodes with the same identifiers but different images.