### PR TITLE
Bug fix - MoleculeGraph.split_molecule_subgraphs

### DIFF
--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -2495,56 +2495,11 @@ class MoleculeGraph(MSONable):
 
         isomorphic = nx.is_isomorphic(self_undir, other_undir, node_match=nm)
 
-        if isomorphic and self.molecule.composition != other.molecule.composition: # This should not be possible!!!
-            print(self.molecule.composition)
-            print(self.molecule)
-            print(other.molecule.composition)
-            print(other.molecule)
-            print()
+        if isomorphic and self.molecule.composition != other.molecule.composition:
+            raise RuntimeError("Anomaly: graph is isomorphic, but species in"
+                               " molecules are different.")
 
         return isomorphic
-
-    def equivalent_to(self, other):
-        """
-        A weaker equality function that evaluates isomorphisms between two
-        MoleculeGraphs. If there is an isomorphism where the species are
-        identical for each pair, then the MoleculeGraphs are considered
-        "equivalent".
-
-        :param other: The MoleculeGraph to be compared to this MoleculeGraph
-        :return: Bool
-        """
-
-        # If they're already equivalent, don't worry about it.
-        if self.__eq__(other):
-            return True
-
-        # Associate each node with a species, coordinates
-        self.set_node_attributes()
-        other.set_node_attributes()
-
-        # The possibility of multiple edges eliminates possible isomorphisms
-        self_undir = self.graph.to_undirected()
-        other_undir = other.graph.to_undirected()
-
-        matcher = nx.algorithms.isomorphism.GraphMatcher(self_undir,
-                                                         other_undir)
-
-        # Graph equality requires that there be an appropriate mapping between
-        # nodes in the graph
-        if not matcher.is_isomorphic():
-            return False
-
-        for mapping in matcher.isomorphisms_iter():
-            self_spec = nx.get_node_attributes(self_undir, "specie")
-            other_spec = nx.get_node_attributes(other_undir, "specie")
-            truths = [self_spec[i] == other_spec[mapping[i]] for i in mapping]
-
-            if all(truths):
-                return True
-
-        # No isomorphism was perfect
-        return False
 
     def diff(self, other, strict=True):
         """

--- a/pymatgen/analysis/graphs.py
+++ b/pymatgen/analysis/graphs.py
@@ -1734,7 +1734,6 @@ class MoleculeGraph(MSONable):
             original.break_edge(bond[0], bond[1], allow_reverse=allow_reverse)
 
         if nx.is_weakly_connected(original.graph):
-            #TODO: test
             raise RuntimeError("Cannot split molecule; \
                                 MoleculeGraph is still connected.")
         else:
@@ -1772,7 +1771,6 @@ class MoleculeGraph(MSONable):
 
                 # just give charge to whatever subgraph has node with index 0
                 # TODO: actually figure out how to distribute charge
-                # TODO: test
                 if 0 in nodes:
                     charge = self.molecule.charge
                 else:
@@ -1792,6 +1790,12 @@ class MoleculeGraph(MSONable):
                             properties[prop].append(prop_set[prop])
                         else:
                             properties[prop] = [prop_set[prop]]
+
+                # Site properties must be present for all atoms in the molecule
+                # in order to be used for Molecule instantiation
+                for k, v in properties.items():
+                    if len(v) != len(species):
+                        del properties[k]
 
                 new_mol = Molecule(species, coords, charge=charge,
                                    site_properties=properties)

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -626,7 +626,7 @@ class MoleculeGraphTest(unittest.TestCase):
         no_rings = self.butadiene.find_rings()
         self.assertEqual(no_rings, [])
 
-    def test_equivalent_to_isomorphic_to(self):
+    def test_isomorphic_to(self):
         ethylene = Molecule.from_file(os.path.join(os.path.dirname(__file__),
                                                    "..", "..", "..",
                                                    "test_files/graphs/ethylene.xyz"))
@@ -641,9 +641,6 @@ class MoleculeGraphTest(unittest.TestCase):
         eth_copy.add_edge(1, 3, weight=1.0)
         eth_copy.add_edge(0, 4, weight=1.0)
         eth_copy.add_edge(0, 5, weight=1.0)
-
-        self.assertTrue(self.ethylene.equivalent_to(eth_copy))
-        self.assertFalse(self.ethylene.equivalent_to(self.butadiene))
 
         # If they are equal, they must also be isomorphic
         eth_copy = copy.deepcopy(self.ethylene)

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -573,6 +573,7 @@ class MoleculeGraphTest(unittest.TestCase):
                                                              {"from_index": 1, "to_index": 3}])
         self.assertEqual(eth_copy.get_coordination_of_site(1), 2)
 
+    @unittest.skipIf(not nx, "NetworkX not present. Skipping...")
     def test_split(self):
         bonds = [(0, 1), (4, 5)]
         alterations = {(2, 3): {"weight": 1.0},

--- a/pymatgen/analysis/tests/test_graphs.py
+++ b/pymatgen/analysis/tests/test_graphs.py
@@ -32,6 +32,7 @@ __date__ = "August 2017"
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
+
 class StructureGraphTest(unittest.TestCase):
 
     def setUp(self):
@@ -120,12 +121,14 @@ class StructureGraphTest(unittest.TestCase):
 
         specie = nx.get_node_attributes(self.square_sg.graph, "specie")
         coords = nx.get_node_attributes(self.square_sg.graph, "coords")
+        properties = nx.get_node_attributes(self.square_sg.graph, "properties")
 
-        self.assertEqual(str(specie[0]), str(self.square_sg.structure[0].specie))
-        self.assertEqual(str(specie[0]), "H")
-        self.assertEqual(coords[0][0], self.square_sg.structure[0].coords[0])
-        self.assertEqual(coords[0][1], self.square_sg.structure[0].coords[1])
-        self.assertEqual(coords[0][2], self.square_sg.structure[0].coords[2])
+        for i in range(len(self.square_sg.structure)):
+            self.assertEqual(str(specie[i]), str(self.square_sg.structure[i].specie))
+            self.assertEqual(coords[i][0], self.square_sg.structure[i].coords[0])
+            self.assertEqual(coords[i][1], self.square_sg.structure[i].coords[1])
+            self.assertEqual(coords[i][2], self.square_sg.structure[i].coords[2])
+            self.assertEqual(properties[i], self.square_sg.structure[i].properties)
 
     def test_edge_editing(self):
         square = copy.deepcopy(self.square_sg)
@@ -523,12 +526,14 @@ class MoleculeGraphTest(unittest.TestCase):
 
         specie = nx.get_node_attributes(self.ethylene.graph, "specie")
         coords = nx.get_node_attributes(self.ethylene.graph, "coords")
+        properties = nx.get_node_attributes(self.ethylene.graph, "properties")
 
-        self.assertEqual(str(specie[0]), str(self.ethylene.molecule[0].specie))
-        self.assertEqual(str(specie[0]), "C")
-        self.assertEqual(coords[0][0], self.ethylene.molecule[0].coords[0])
-        self.assertEqual(coords[0][1], self.ethylene.molecule[0].coords[1])
-        self.assertEqual(coords[0][2], self.ethylene.molecule[0].coords[2])
+        for i in range(len(self.ethylene.molecule)):
+            self.assertEqual(str(specie[i]), str(self.ethylene.molecule[i].specie))
+            self.assertEqual(coords[i][0], self.ethylene.molecule[i].coords[0])
+            self.assertEqual(coords[i][1], self.ethylene.molecule[i].coords[1])
+            self.assertEqual(coords[i][2], self.ethylene.molecule[i].coords[2])
+            self.assertEqual(properties[i], self.ethylene.molecule[i].properties)
 
     def test_coordination(self):
         molecule = Molecule(['C', 'C'], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
@@ -575,14 +580,31 @@ class MoleculeGraphTest(unittest.TestCase):
                        (1, 2): {"weight": 2.0},
                        (3, 4): {"weight": 2.0}
                        }
-        # Perform reverse Diels-Alder reaction - turn product into reactants
-        reactants = self.cyclohexene.split_molecule_subgraphs(bonds, alterations=alterations)
+        # Perform retro-Diels-Alder reaction - turn product into reactants
+        reactants = self.cyclohexene.split_molecule_subgraphs(bonds,
+                                                              allow_reverse=True,
+                                                              alterations=alterations)
         self.assertTrue(isinstance(reactants, list))
 
         reactants = sorted(reactants, key=len)
         # After alterations, reactants sholuld be ethylene and butadiene
         self.assertEqual(reactants[0], self.ethylene)
         self.assertEqual(reactants[1], self.butadiene)
+
+        with self.assertRaises(RuntimeError):
+            self.cyclohexene.split_molecule_subgraphs([(0,1)])
+
+        hydroxide = Molecule(["O", "H"], [[0, 0, 0], [0.5, 0.5, 0.5]], charge=-1)
+        oh_mg = MoleculeGraph.with_empty_graph(hydroxide)
+
+        oh_mg.add_edge(0, 1)
+
+        new_mgs = oh_mg.split_molecule_subgraphs([(0,1)])
+        for mg in new_mgs:
+            if str(mg.molecule[0].specie) == "O":
+                self.assertEqual(mg.molecule.charge, -1)
+            else:
+                self.assertEqual(mg.molecule.charge, 0)
 
     @unittest.skipIf(not nx, "NetworkX not present. Skipping...")
     def test_build_unique_fragments(self):
@@ -593,7 +615,8 @@ class MoleculeGraphTest(unittest.TestCase):
         for ii in range(295):
             for jj in range(ii + 1, 295):
                 self.assertEqual(
-                    nx.is_isomorphic(unique_fragments[ii], unique_fragments[jj],
+                    nx.is_isomorphic(unique_fragments[ii].graph,
+                                     unique_fragments[jj].graph,
                                      node_match=nm), False)
 
     def test_find_rings(self):


### PR DESCRIPTION
Previously, MoleculeGraph.split_molecule_subgraphs used an inelegant remapping algorithm to link the graph data and Molecule data after a split. Occasionally, this mapping failed, causing MoleculeGraph.molecule and MoleculeGraph.graph to have different atoms at different indices. This pull request fixes this bug by removing the remapping algorithm and replacing it with one that relies on MoleculeGraph.set_node_attributes (which automatically links Molecule and node information). Additionally, some tests have been added to make MoleculeGraph more robust (this is still a work in progress).